### PR TITLE
feat: added an output for the error messsage

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: "Additional node dependencies, ignored if node_modules is provided"
     default: |
       @commitlint/config-conventional@^19.5.0
+outputs:
+  error_message:
+    description: "Error message"
+    value: ${{ steps.commitlint.outputs.error_message }}
 
 runs:
   using: "composite"
@@ -100,6 +104,7 @@ runs:
 
     - name: Run commitlint
       shell: bash
+      id: commitlint
       working-directory: ${{ steps.resolve-working-directory.outputs.result }}
       env:
         PR_TITLE: ${{ inputs.pr_title }}
@@ -107,8 +112,14 @@ runs:
         NODE_PATH: ${{ steps.resolve-working-directory.outputs.result }}/node_modules
       run: |
         # Running commitlint
-        echo "$PR_TITLE" | npx commitlint \
-          --config $CONFIG_FILE
+
+        if ! error_message=$(echo "$PR_TITLE" | npx commitlint --config $CONFIG_FILE 2>&1); then
+          echo "error_message<<EOF" >> $GITHUB_OUTPUT
+          echo "$error_message" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "::error::$error_message"
+          exit 1
+        fi
 
     - name: Remove temporary directory
       shell: bash


### PR DESCRIPTION
This pull request includes changes to the `action.yaml` file to handle error messages more effectively when running `commitlint`. The most important changes include adding an output for error messages and modifying the `Run commitlint` step to capture and output error messages.

Enhancements to error handling:

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR27-R30): Added an `outputs` section to define `error_message` for capturing error messages from `commitlint`.
* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR107-R122): Modified the `Run commitlint` step to include an `id` and updated the script to capture error messages, output them to GitHub Actions, and display them as errors.